### PR TITLE
Always return list of groups on CredentialValidationResult, never null

### DIFF
--- a/src/main/java/javax/security/identitystore/CredentialValidationResult.java
+++ b/src/main/java/javax/security/identitystore/CredentialValidationResult.java
@@ -144,11 +144,10 @@ public class CredentialValidationResult {
 
         if (status == VALID) {
             this.callerPrincipal = callerPrincipal;
-            // TODO: to be discussed, should we use null or empty list?
             this.groups = groups != null ? unmodifiableList(new ArrayList<>(groups)) : emptyList();
         } else {
             this.callerPrincipal = null;
-            this.groups = null;
+            this.groups = emptyList();
         }
     }
 
@@ -170,8 +169,7 @@ public class CredentialValidationResult {
      * the associated identity store.
      *
      * @return The list of groups that the specified Caller is in, empty if
-     * none. <code>null</code> if {@link #getStatus} does not return
-     * {@link Status#VALID VALID}
+     * none.
      */
     public List<String> getCallerGroups() {
         return groups;


### PR DESCRIPTION
This is a proposal that may deserve a discussion on the mailing list.

The idea to return null in case of not valid result seems to come from a JASPIC requirement. But this API is built on top on JASPIC precisely to simplify it to end users. It's an accepted good practice to return empty lists instead of nulls.

The implementation is reponsible for passing a null value to JASPIC. Soteria already does that on its two only affected methods:
https://github.com/javaee-security-spec/soteria/blob/00ebdf752f8a32689653e2ee5e358ab7947ff3c5/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java#L302
https://github.com/javaee-security-spec/soteria/blob/00ebdf752f8a32689653e2ee5e358ab7947ff3c5/impl/src/main/java/org/glassfish/soteria/mechanisms/HttpMessageContextImpl.java#L322

Thoughts?