### PR TITLE
Publish JavaDoc to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Java EE Security (JSR 375) API
 
-This code represents the JSR-375 API. 
+This code represents the JSR-375 API.
+
+[Online JavaDoc](https://javaee-security-spec.github.io/security-api/).
 
 Building
 --------

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
                 </configuration>
             </plugin>
             <!-- Configure the jar with the sources (or rather, convince Maven that 
-                                we want sources at all) -->
+            we want sources at all) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
@@ -112,7 +112,7 @@
                 </executions>
             </plugin>
             <!-- Configure the jar with the javadoc (or rather, convince Maven that 
-                                we want javadoc at all) -->
+            we want javadoc at all) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -216,6 +216,18 @@
                             </pluginExecution>
                         </pluginExecutions>
                     </lifecycleMappingMetadata>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-publish-plugin</artifactId>
+                <version>1.1</version>
+                <configuration>
+                    <checkoutDirectory>${project.build.directory}/javadoc-scm</checkoutDirectory>
+                    <checkinComment>Publishing Javadoc for ${project.artifactId}:${project.version}</checkinComment>
+                    <content>${project.reporting.outputDirectory}/apidocs</content>
+                    <pubScmUrl>scm:git:git@github.com:javaee-security-spec/security-api.git</pubScmUrl>
+                    <scmBranch>gh-pages</scmBranch>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Branch "gh-pages" needs to be created before the "scm-publish:publish-scm" can be called. Results will then be available at https://javaee-security-spec.github.io/security-api/

Travis should be configured to run that goal for each merged pull request.