### PR TITLE
Use the passed in status in the CredentialValidationResult

### DIFF
--- a/src/main/java/javax/security/identitystore/CredentialValidationResult.java
+++ b/src/main/java/javax/security/identitystore/CredentialValidationResult.java
@@ -176,7 +176,7 @@ public class CredentialValidationResult {
             throw new IllegalArgumentException("Null or empty CallerPrincipal");
         }
 
-        this.status = VALID;
+        this.status = status;
         this.storeId = storeId;
         this.callerPrincipal = callerPrincipal;
         this.callerUniqueId = callerUniqueId;


### PR DESCRIPTION
Discovered that the status in a credential validation result was always being set to valid while bringing the RI up to date with the current spec version. This was causing IllegalArgumentExceptions in the tests for the RI once the updates were complete.