### PR TITLE
IdentityStore#validationTypes() returns inmutable set

### DIFF
--- a/src/main/java/javax/security/identitystore/IdentityStore.java
+++ b/src/main/java/javax/security/identitystore/IdentityStore.java
@@ -123,7 +123,7 @@ public class ExampleIdentityStore implements IdentityStore {
     /**
      * Determines the type of validation the IdentityStore should be used for. 
      * By default, its used for credential validation AND providing groups.
-     * @return Type of validation.
+     * @return Inmutable set of validation types this identity store will perform.
      */
     default Set<ValidationType> validationTypes() {
         return DEFAULT_VALIDATION_TYPES;

--- a/src/main/java/javax/security/identitystore/IdentityStore.java
+++ b/src/main/java/javax/security/identitystore/IdentityStore.java
@@ -123,7 +123,9 @@ public class ExampleIdentityStore implements IdentityStore {
     /**
      * Determines the type of validation the IdentityStore should be used for. 
      * By default, its used for credential validation AND providing groups.
-     * @return Inmutable set of validation types this identity store may perform.
+     * Changes made to the returned {@link Set} should not be reflected on the underlying collection
+     *
+     * @return validation types this identity store may perform.
      */
     default Set<ValidationType> validationTypes() {
         return DEFAULT_VALIDATION_TYPES;

--- a/src/main/java/javax/security/identitystore/IdentityStore.java
+++ b/src/main/java/javax/security/identitystore/IdentityStore.java
@@ -123,7 +123,7 @@ public class ExampleIdentityStore implements IdentityStore {
     /**
      * Determines the type of validation the IdentityStore should be used for. 
      * By default, its used for credential validation AND providing groups.
-     * @return Inmutable set of validation types this identity store will perform.
+     * @return Inmutable set of validation types this identity store may perform.
      */
     default Set<ValidationType> validationTypes() {
         return DEFAULT_VALIDATION_TYPES;


### PR DESCRIPTION
I'm not sure about the wording, but it must be clear that the original set cannot be modified to influence the validation types.

There are other classes where this can be applied, like https://github.com/javaee-security-spec/security-api/blob/master/src/main/java/javax/security/identitystore/CredentialValidationResult.java

I'll update the PR in you think it's valuable to add the same clarification to other affeceted places. In the CredentialValidationResult case, it may be enough the add a comment at the class level stating that "once created, this object is expected to be inmutable".