### PR TITLE
Pluralized table name in DatabaseIdentityStoreDefinition example

### DIFF
--- a/src/main/java/javax/security/enterprise/identitystore/DataBaseIdentityStoreDefinition.java
+++ b/src/main/java/javax/security/enterprise/identitystore/DataBaseIdentityStoreDefinition.java
@@ -81,7 +81,7 @@ public @interface DataBaseIdentityStoreDefinition {
 	 * Example query:
 	 * <pre>
 	 * <code>
-	 * select password from caller where name = ?
+	 * select password from callers where name = ?
 	 * </code>
 	 * </pre>
 	 * 


### PR DESCRIPTION
Table names are usually plural, as in the `groupsQuery` example.