### PR TITLE
Made PasswordHash#initialize() method default

### DIFF
--- a/src/main/java/javax/security/enterprise/identitystore/DatabaseIdentityStoreDefinition.java
+++ b/src/main/java/javax/security/enterprise/identitystore/DatabaseIdentityStoreDefinition.java
@@ -43,6 +43,7 @@ import static java.lang.annotation.ElementType.TYPE;
 import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Target;
+import java.util.stream.Stream;
 import javax.security.enterprise.identitystore.IdentityStore.ValidationType;
 import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.PROVIDE_GROUPS;
 import static javax.security.enterprise.identitystore.IdentityStore.ValidationType.VALIDATE;
@@ -131,10 +132,12 @@ public @interface DatabaseIdentityStoreDefinition {
      * <li>PBKDF2.salt
      * </ul>
      * 
-     * <p>
-     *  Parameters are specified using the format:
-     *  <i>parameterName=parameterValue</i> with one parameter per array element.
-     * 
+     *  <p>
+     *  This attribute supports immediate EL expressions (${} syntax) for both the
+     *  <code>parameterValue</code> as well as for a full array element. If an EL
+     *  expression is used for a full array element, the expression must evaluate
+     *  to either a single string, a string array or a string {@link Stream} where
+     *  in each case every string must adhere to the above specified format. 
      */
     String[] hashAlgorithmParameters() default {};
     

--- a/src/main/java/javax/security/enterprise/identitystore/PasswordHash.java
+++ b/src/main/java/javax/security/enterprise/identitystore/PasswordHash.java
@@ -60,7 +60,8 @@ public interface PasswordHash {
      *
      * @param parameters A {@link Map} of the provided parameters, empty if no parameters were supplied.
      */
-    void initialize(Map<String, String> parameters);
+    default void initialize(Map<String, String> parameters) {
+    }
 
     /**
      * Generate an encoded password hash value for storage in a user's account.


### PR DESCRIPTION
I imagine most of the time custom implementations created by users won't use parameters.