### PR TITLE
Fix imports of JACC and JCA types

### DIFF
--- a/src/main/java/javax/security/enterprise/SecurityContext.java
+++ b/src/main/java/javax/security/enterprise/SecurityContext.java
@@ -45,7 +45,6 @@ import java.util.Set;
 import javax.ejb.SessionContext;
 import javax.security.enterprise.authentication.mechanism.http.AuthenticationParameters;
 import javax.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
-import javax.security.jacc.WebResourcePermission;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -119,7 +118,7 @@ public interface SecurityContext {
      * 
      * @param resource the name of the web resource to test access for. This is a <code>URLPatternSpec</code> that 
      * identifies the application specific web resources to which the permission pertains. For a full specification of this
-     * pattern see {@link WebResourcePermission#WebResourcePermission(String, String)}.
+     * pattern see {@link javax.security.jacc.WebResourcePermission#WebResourcePermission(String, String)}.
      * @param methods one or more methods to check for whether the caller has access to the web resource using one of those methods.
      * 
      * @return <code>true</code> if the caller has access to the web resource using one of the given methods, <code>false</code> otherwise. 

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/AutoApplySession.java
@@ -47,11 +47,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.interceptor.InterceptorBinding;
-import javax.resource.spi.AuthenticationMechanism;
 
 /**
  * The AutoApplySession annotation provides an application the ability to declarative designate 
- * that an {@link AuthenticationMechanism} uses the <code>javax.servlet.http.registerSession</code> 
+ * that an {@link javax.resource.spi.AuthenticationMechanism} uses the <code>javax.servlet.http.registerSession</code>
  * and auto applies this for every request.
  * 
  * <p>

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
@@ -45,10 +45,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.resource.spi.AuthenticationMechanism;
 
 /**
- * Annotation used to define a container {@link AuthenticationMechanism} that implements
+ * Annotation used to define a container {@link javax.resource.spi.AuthenticationMechanism} that implements
  * the HTTP basic access authentication protocol as defined by the Servlet spec (13.6.1)  
  * and make that implementation available as an enabled CDI bean.
  *

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
@@ -46,11 +46,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.enterprise.util.Nonbinding;
-import javax.resource.spi.AuthenticationMechanism;
 import javax.security.enterprise.SecurityContext;
 
 /**
- * Annotation used to define a container {@link AuthenticationMechanism} that implements
+ * Annotation used to define a container {@link javax.resource.spi.AuthenticationMechanism} that implements
  * authentication mechanism resembling the Servlet FORM one (Servlet spec 13.6.3).
  * <p> 
  * Instead of posting back to a predefined action to continue the authentication dialog 

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
@@ -46,10 +46,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.enterprise.util.Nonbinding;
-import javax.resource.spi.AuthenticationMechanism;
 
 /**
- * Annotation used to define a container {@link AuthenticationMechanism} that implements the
+ * Annotation used to define a container {@link javax.resource.spi.AuthenticationMechanism} that implements the
  * FORM authentication mechanism as defined by the Servlet spec (13.6.3) and make that 
  * implementation available as an enabled CDI bean.
  *

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/LoginToContinue.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/LoginToContinue.java
@@ -48,11 +48,10 @@ import java.lang.annotation.Target;
 
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
-import javax.resource.spi.AuthenticationMechanism;
 
 /**
  * The <code>LoginToContinue</code> annotation provides an application the ability to declaratively 
- * add login to continue functionality to an {@link AuthenticationMechanism}.
+ * add login to continue functionality to an {@link javax.resource.spi.AuthenticationMechanism}.
  * 
  * <p>
  * When the <code>LoginToContinue</code> annotation is used on a custom authentication mechanism, EL

--- a/src/main/java/javax/security/enterprise/authentication/mechanism/http/RememberMe.java
+++ b/src/main/java/javax/security/enterprise/authentication/mechanism/http/RememberMe.java
@@ -49,14 +49,13 @@ import java.lang.annotation.Target;
 import javax.el.ELProcessor;
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
-import javax.resource.spi.AuthenticationMechanism;
 import javax.security.enterprise.identitystore.IdentityStore;
 import javax.security.enterprise.identitystore.RememberMeIdentityStore;
 import javax.servlet.http.Cookie;
 
 /**
  * The RememberMe annotation provides an application the ability to declarative designate 
- * that an {@link AuthenticationMechanism} effectively "remembers" the authentication and auto
+ * that an {@link javax.resource.spi.AuthenticationMechanism} effectively "remembers" the authentication and auto
  * applies this with every request.
  * 
  * <p>

--- a/src/main/java/javax/security/enterprise/identitystore/Pbkdf2PasswordHash.java
+++ b/src/main/java/javax/security/enterprise/identitystore/Pbkdf2PasswordHash.java
@@ -74,7 +74,6 @@ Java Cryptography Architecture Standard Algorithm Name Documentation</a>.
 {@code <algorithm>:<iterations>:<base64(salt)>:<base64(hash)>}
  * </pre></blockquote>
  * Where:
- * <p>
  * <ul>
  * <li><i>algorithm</i> -- the algorithm used to generate the hash
  * <li><i>iterations</i> -- the number of iterations used to generate the hash


### PR DESCRIPTION
Imports were needed only for javadoc, but caused the build of the Web Profile API jar to have dependencies on non-Web Profile classes. Removed imports and used FQNs for the javadoc links.